### PR TITLE
Changing *FS.client type definition to goredis.Cmdable interface

### DIFF
--- a/io/cache/redis/redis.go
+++ b/io/cache/redis/redis.go
@@ -76,6 +76,14 @@ func WithRedisCluster(args ClusterArgs) Option {
 	}
 }
 
+// WithExistingClient uses an existing Redis connection pool as the backend.
+func WithExistingClient(c redis.Cmdable) Option {
+	return func(f *FS) error {
+		f.client = c
+		return nil
+	}
+}
+
 type writeFileOptions struct {
 	regex   *regexp.Regexp
 	options []jsfs.OFOption

--- a/io/cache/redis/redis_test.go
+++ b/io/cache/redis/redis_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"testing"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -10,11 +11,11 @@ func TestRedis(t *testing.T) {
 	const testFile = "path/to/test/file"
 	const testContent = "content"
 
-	args := Args{
+	args := &redis.Options{
 		Addr: "127.0.0.1:6379",
 	}
 
-	redisFS, err := New(args)
+	redisFS, err := New(redis.NewClient(args))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Addresses issue #2 with the following changes:

- Changes the `New` constructor to accept `redis.Cmdable` interface instead of `redis.Client`
- Adds `redis.Cmdable` implementation checks on various clients:
i. `redis.Client`
ii. `redis.ClusterClient`
iii. `redis.Pipeline`
- Removed `Args` type
- Added note regarding redis server version >= 6.0 dependency based on `KeepTTL` arg. See:

https://github.com/dhh93/fs/blob/4bca13f547cd1e87d3c533bc8d8fde1255a38b30/io/cache/redis/redis.go#L84
      
